### PR TITLE
Fix readthedocs docs generation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: osquery
+site_name: osql
 theme: readthedocs
 
 docs_dir: docs/wiki

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,12 @@
+version: 2
+
+submodules:
+  include: all
+
+mkdocs:
+  configuration: mkdocs.yml
+  fail_on_warning: false
+
+python:
+  version: 3.6
+


### PR DESCRIPTION
This fixes the generation of the documentation at https://osql.readthedocs.io/en/latest/

Since we renamed repositories, that version is actually from the osql-experimental branch, but the osql build was failing.
The configuration is now the same as the one for osql-experimental, which works.

Here https://osql.readthedocs.io/en/stefano-fix-docs/ is the version that builds correctly, connected to this PR.