### PR TITLE
Fix wrong error code returned when querying the Windows registry

### DIFF
--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -249,7 +249,7 @@ Status queryKey(const std::string& keyPath, QueryData& results) {
   reg_handle_t hRegistryHandle(hkey, closeRegHandle);
 
   if (ret != ERROR_SUCCESS) {
-    return Status(GetLastError(), "Failed to open registry handle");
+    return Status(ret, "Failed to open registry handle");
   }
 
   const DWORD maxKeyLength = 255;
@@ -273,7 +273,7 @@ Status queryKey(const std::string& keyPath, QueryData& results) {
                             nullptr,
                             &ftLastWriteTime);
   if (retCode != ERROR_SUCCESS) {
-    return Status(GetLastError(), "Failed to query registry info for key");
+    return Status(retCode, "Failed to query registry info for key");
   }
   auto achKey = std::make_unique<TCHAR[]>(maxKeyLength);
   DWORD cbName;
@@ -291,7 +291,7 @@ Status queryKey(const std::string& keyPath, QueryData& results) {
                              nullptr,
                              &ftLastWriteTime);
       if (retCode != ERROR_SUCCESS) {
-        return Status(GetLastError(), "Failed to enumerate registry key");
+        return Status(retCode, "Failed to enumerate registry key");
       }
 
       Row r;
@@ -326,7 +326,7 @@ Status queryKey(const std::string& keyPath, QueryData& results) {
                            nullptr,
                            nullptr);
     if (retCode != ERROR_SUCCESS) {
-      return Status(GetLastError(), "Failed to enumerate registry values");
+      return Status(retCode, "Failed to enumerate registry values");
     }
 
     DWORD lpData = cbMaxValueData;
@@ -339,7 +339,7 @@ Status queryKey(const std::string& keyPath, QueryData& results) {
                               bpDataBuff.get(),
                               &lpData);
     if (retCode != ERROR_SUCCESS) {
-      return Status(GetLastError(), "Failed to query registry value");
+      return Status(retCode, "Failed to query registry value");
     }
 
     // It's possible for registry entries to have been inserted incorrectly

--- a/osquery/tables/system/windows/tests/registry_tests.cpp
+++ b/osquery/tables/system/windows/tests/registry_tests.cpp
@@ -37,7 +37,7 @@ TEST_F(RegistryTablesTest, test_registry_existing_key) {
 TEST_F(RegistryTablesTest, test_registry_non_existing_key) {
   QueryData results;
   auto ret = queryKey(kInvalidTestKey, results);
-  EXPECT_TRUE(ret.ok());
+  EXPECT_FALSE(ret.ok());
   EXPECT_TRUE(results.size() == 0);
 }
 


### PR DESCRIPTION
Calling GetLastError() will not return the error code for the Windows registry APIs,
since they return a LSTATUS value which already is the error code.

This also fixes the RegistryTablesTest.test_registry_non_existing_key
test case which was incorrectly expecting success when querying
for a non-existent registry key.
