### PR TITLE
Fix rpm builder script to not break because of symlinks

### DIFF
--- a/tools/deployment/getfiles.py
+++ b/tools/deployment/getfiles.py
@@ -51,5 +51,5 @@ if __name__ == "__main__":
             continue
         if file['file'].find("gtest") > 0:
             continue
-        print(file['file'].replace(args.base, ""))
+        print(file['file'])
         pass

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -279,7 +279,7 @@ function main() {
     for file in `"$SCRIPT_DIR/getfiles.py" --build "$BUILD_DIR/" --base "$SOURCE_DIR/"`
     do
       mkdir -p `dirname "$SOURCE_DEBUG_DIR/$file"`
-      cp "$SOURCE_DIR/$file" "$SOURCE_DEBUG_DIR/$file"
+      cp "$file" "$SOURCE_DEBUG_DIR/$file"
     done
   fi
 


### PR DESCRIPTION
This is a fix for #57 

The python script `getfiles.py` is being used to collect the names of all source files which is passed back into `make_linux_package.sh` for collection. The python script removed the base of the path which was re-prepended in the bash script. This would be an issue for symlinks which would be evaluated in python.