### PR TITLE
Change windows deployment location to the Program Files directory

### DIFF
--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -29,7 +29,7 @@ The default config plugin, **filesystem**, reads from a file and optional
 directory ".d" based on the filename. The included initscripts set the default
 config path as follows:
 
-* Windows: **C:\ProgramData\osquery\osquery.conf**
+* Windows: **C:\Program Files\osquery\osquery.conf**
 * Linux: **/etc/osquery/osquery.conf** and **/etc/osquery/osquery.conf.d/**
 * MacOS: **/var/osquery/osquery.conf** and **/var/osquery/osquery.conf.d/**
 

--- a/docs/wiki/deployment/logging.md
+++ b/docs/wiki/deployment/logging.md
@@ -15,7 +15,7 @@ lrwxr-xr-x   1 root  wheel    77 Sep 30 17:37 osqueryd.INFO -> osqueryd.INFO.201
 -rw-------   1 root  wheel   388 Sep 30 17:37 osqueryd.results.log
 ```
 
-On Windows this directory defaults to `C:\ProgramData\osquery\log`.
+On Windows this directory defaults to `C:\Program Files\osquery\log`.
 
 ## Logger plugins
 

--- a/docs/wiki/installation/install-windows.md
+++ b/docs/wiki/installation/install-windows.md
@@ -8,7 +8,7 @@ We recommend installing Windows via the Chocolatey package system however a help
 
 Each osquery tag (stable release) is published to **chocolatey** for our supported versions: [https://chocolatey.org/packages/osquery/](https://chocolatey.org/packages/osquery/)
 
-By default Chocolatey will install the binaries, example packs, example configuration, and an OpenSSL certificate bundle to `C:\ProgramData\osquery` and nothing more. You can pass Chocolatey the `--params='/InstallService'` flag or make use of osquery's `--install` flag with `C:\ProgramData\osquery\osqueryd\osqueryd.exe --install` to install a Windows SYSTEM level service for the **osqueryd** daemon.
+By default Chocolatey will install the binaries, example packs, example configuration, and an OpenSSL certificate bundle to `C:\Program Files\osquery` and nothing more. You can pass Chocolatey the `--params='/InstallService'` flag or make use of osquery's `--install` flag with `C:\Program Files\osquery\osqueryd\osqueryd.exe --install` to install a Windows SYSTEM level service for the **osqueryd** daemon.
 
 ### Installing osquery via the MSI package
 
@@ -29,38 +29,38 @@ The recommended way to set these ACLs is with Powershell and we've written a hel
 C:\Users\Thor\work\repos\osquery [master ≡]
 λ  . .\tools\provision\chocolatey\osquery_utils.ps1
 C:\Users\Thor\work\repos\osquery [master ≡]
-λ  Set-SafePermissions C:\ProgramData\osquery\osqueryd\
+λ  Set-SafePermissions C:\Program Files\osquery\osqueryd\
 True
 ```
 
-If you'd prefer to manually set the permissions check the `C:\ProgramData\osquery\osqueryd` directory and ensure that no users or groups have write permissions with the exception of the Administrators group or the SYSTEM account. Read and execute permissions are expected and safe so also ensure the Users group has both.
+If you'd prefer to manually set the permissions check the `C:\Program Files\osquery\osqueryd` directory and ensure that no users or groups have write permissions with the exception of the Administrators group or the SYSTEM account. Read and execute permissions are expected and safe so also ensure the Users group has both.
 
 Now that osquery is properly laid out on disk we need to create a new Windows service to launch and manage the daemon. If you're using Chocolatey you can pass the `--params='/InstallService'` flag during installation to have Chocolatey setup the Windows service for you. In general any method to install a Windows system service will suffice, one simply needs to ensure to specify the `--flagfile` option in the service binary path and give the full paths for the daemon binary and flag file both. Some examples follow:
 
 * To install the service using Powershell we bundle a helper function living in the repo at `.\tools\manage-windows-service.ps1` which can be invoked as follows:
 
 ````
-C:\ProgramData\osquery
-λ  .\manage-osqueryd.ps1 -install -startupArgs C:\ProgramData\osquery\osquery.flags
+C:\Program Files\osquery
+λ  .\manage-osqueryd.ps1 -install -startupArgs C:\Program Files\osquery\osquery.flags
 ````
 
 * If you'd rather use Powershell to manually create the service you can run:
 
 ```
 C:\Users\Thor\work\repos\osquery [master ≡]
-λ  New-Service -Name "osqueryd" -BinaryPathName "C:\ProgramData\osquery\osqueryd\osqueryd.exe --flagfile=C:\ProgramData\osquery\osquery.flags"
+λ  New-Service -Name "osqueryd" -BinaryPathName "C:\Program Files\osquery\osqueryd\osqueryd.exe --flagfile=C:\Program Files\osquery\osquery.flags"
 ```
 
 * Lastly, if you'd prefer to use the Windows service utility `sc.exe` you can use:
 
 ```
 C:\Users\Thor\work\repos\osquery [master ≡]
-λ  sc.exe create osqueryd type= own start= auto error= normal binpath= "C:\ProgramData\osquery\osqueryd\osqueryd.exe --flagfile=\ProgramData\osquery\osquery.flags" displayname= 'osqueryd'
+λ  sc.exe create osqueryd type= own start= auto error= normal binpath= "C:\Program Files\osquery\osqueryd\osqueryd.exe --flagfile=\Program Files\osquery\osquery.flags" displayname= 'osqueryd'
 ```
 
 ## Running osquery
 
-Out of the box osquery is runnable via the Chocolatey installation. More commonly however the daemon is configured to be a system service. To set this up, you'll need to install the daemon via the service installation flags as detailed in the steps above, and then provide the daemon with a config file. The simplest way to get **osqueryd** up and running is to rename the `C:\ProgramData\osquery\osquery.example.conf` file provided to `osquery.conf`. Once the configuration file is in place, you can start the Windows service:
+Out of the box osquery is runnable via the Chocolatey installation. More commonly however the daemon is configured to be a system service. To set this up, you'll need to install the daemon via the service installation flags as detailed in the steps above, and then provide the daemon with a config file. The simplest way to get **osqueryd** up and running is to rename the `C:\Program Files\osquery\osquery.example.conf` file provided to `osquery.conf`. Once the configuration file is in place, you can start the Windows service:
 * `Start-Service osqueryd` if you're using **Powershell**
 * `sc.exe start osqueryd` if you're using **cmd.exe**
 
@@ -68,7 +68,7 @@ We recommend configuring large fleets with Chef or SCCM.
 
 ## Managing the daemon service
 
-osquery provides a helper script for [managing the osquery daemon service](https://github.com/facebook/osquery/blob/master/tools/manage-osqueryd.ps1), which is installed to `C:\ProgramData\osquery\manage-osqueryd.ps1`.
+osquery provides a helper script for [managing the osquery daemon service](https://github.com/facebook/osquery/blob/master/tools/manage-osqueryd.ps1), which is installed to `C:\Program Files\osquery\manage-osqueryd.ps1`.
 
 ## Packaging osquery
 
@@ -78,10 +78,10 @@ If you'd like to create your own osquery Chocolatey package you can run [`.\tool
 
 In order to enable support for the Windows Event Log, you have to install the manifest file. To install and uninstall it manually, you can use the built-in **wevtutil** command:
 
- * **Install**: wevtutil im C:\ProgramData\osquery\osquery.man
- * **Uninstall**: wevtutil um C:\ProgramData\osquery\osquery.man
+ * **Install**: wevtutil im C:\Program Files\osquery\osquery.man
+ * **Uninstall**: wevtutil um C:\Program Files\osquery\osquery.man
 
-The same operation can be performed using the osquery manager (C:\ProgramData\osquery\manage-osqueryd.ps1):
+The same operation can be performed using the osquery manager (C:\Program Files\osquery\manage-osqueryd.ps1):
 
  * **Install**: .\manage-osqueryd.ps1 -installWelManifest
  * **Uninstall**: .\manage-osqueryd.ps1 -uninstallWelManifest

--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -88,7 +88,7 @@
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
 #define OSQUERY_CERTS_HOME "/usr/share/osquery/certs/"
 #elif defined(WIN32)
-#define OSQUERY_HOME "\\ProgramData\\osquery\\"
+#define OSQUERY_HOME "\\Program Files\\osquery\\"
 #define OSQUERY_DB_HOME OSQUERY_HOME
 #define OSQUERY_SOCKET "\\\\.\\pipe\\"
 #define OSQUERY_PIDFILE OSQUERY_DB_HOME

--- a/tools/deployment/chocolatey/tools/chocolateyBeforeModify.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyBeforeModify.ps1
@@ -5,13 +5,10 @@
 #  LICENSE file in the root directory of this source tree) and the GPLv2 (found
 #  in the COPYING file in the root directory of this source tree).
 #  You may select, at your option, one of the above-listed licenses.
-. "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)\\osquery_utils.ps1"
 
-$serviceName = 'osqueryd'
-$progData = [System.Environment]::GetEnvironmentVariable('ProgramData')
-$targetFolder = Join-Path $progData "osquery"
-$daemonFolder = Join-Path $targetFolder $serviceName
-$extensionsFolder = Join-Path $targetFolder 'extensions'
+#Requires -Version 3.0
+
+. "$PSScriptRoot\\osquery_utils.ps1"
 
 # Ensure the service is stopped and processes are not running if exists.
 if ((Get-Service $serviceName -ErrorAction SilentlyContinue) -and `
@@ -19,7 +16,7 @@ if ((Get-Service $serviceName -ErrorAction SilentlyContinue) -and `
   Stop-Service $serviceName
   # If we find zombie processes, ensure they're termintated
   $proc = Get-Process | Where-Object { $_.ProcessName -eq 'osqueryd' }
-  if ($proc -ne $null) {
+  if ($null -ne $proc) {
     Stop-Process -Force $proc -ErrorAction SilentlyContinue
   }
 }

--- a/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
@@ -5,17 +5,11 @@
 #  LICENSE file in the root directory of this source tree) and the GPLv2 (found
 #  in the COPYING file in the root directory of this source tree).
 #  You may select, at your option, one of the above-listed licenses.
-. "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)\\osquery_utils.ps1"
 
-$serviceName = 'osqueryd'
-$serviceDescription = 'osquery daemon service'
-$progData = [System.Environment]::GetEnvironmentVariable('ProgramData')
-$targetFolder = Join-Path $progData 'osquery'
-$daemonFolder = Join-Path $targetFolder 'osqueryd'
-$extensionsFolder = Join-Path $targetFolder 'extensions'
-$logFolder = Join-Path $targetFolder 'log'
-$targetDaemonBin = Join-Path $targetFolder 'osqueryd.exe'
-$destDaemonBin = Join-Path $daemonFolder 'osqueryd.exe'
+#Requires -Version 3.0
+
+. "$PSScriptRoot\\osquery_utils.ps1"
+
 $packageParameters = $env:chocolateyPackageParameters
 $arguments = @{}
 
@@ -25,7 +19,7 @@ if ((Get-Service $serviceName -ErrorAction SilentlyContinue) -and `
   Stop-Service $serviceName
   # If we find zombie processes, ensure they're termintated
   $proc = Get-Process | Where-Object { $_.ProcessName -eq 'osqueryd' }
-  if ($proc -ne $null) {
+  if ($null -ne $proc) {
     Stop-Process -Force $proc -ErrorAction SilentlyContinue
   }
 }
@@ -75,8 +69,17 @@ if ($installService) {
   if (-not (Get-Service $serviceName -ErrorAction SilentlyContinue)) {
     Write-Debug 'Installing osquery daemon service.'
     # If the 'install' parameter is passed, we create a Windows service with
-    # the flag file in the default location in \ProgramData\osquery\
-    New-Service -Name $serviceName -BinaryPathName "$destDaemonBin --flagfile=\ProgramData\osquery\osquery.flags" -DisplayName $serviceName -Description $serviceDescription -StartupType Automatic
+    # the flag file in the default location in Program Files
+    $cmd = '"{0}" --flagfile="C:\Program Files\osquery\osquery.flags"' -f $destDaemonBin
+
+    $svcArgs = @{
+      Name = $serviceName
+      BinaryPathName = $cmd
+      DisplayName = $serviceName
+      Description = $serviceDescription
+      StartupType = "Automatic"
+    }
+    New-Service @svcArgs
 
     # If the osquery.flags file doesn't exist, we create a blank one.
     if (-not (Test-Path "$targetFolder\osquery.flags")) {

--- a/tools/deployment/chocolatey/tools/chocolateyuninstall.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyuninstall.ps1
@@ -5,9 +5,10 @@
 #  LICENSE file in the root directory of this source tree) and the GPLv2 (found
 #  in the COPYING file in the root directory of this source tree).
 #  You may select, at your option, one of the above-listed licenses.
-$progData = [System.Environment]::GetEnvironmentVariable('ProgramData')
-$targetFolder = Join-Path $progData "osquery"
-$serviceName = 'osqueryd'
+
+#Requires -Version 3.0
+
+. "$PSScriptRoot\\osquery_utils.ps1"
 
 # Remove the osquery path from the System PATH variable. Note: Here
 # we don't make use of our local vars, as Regex requires escaping the '\'
@@ -22,7 +23,7 @@ if ((Get-Service $serviceName -ErrorAction SilentlyContinue)) {
   
   # If we find zombie processes, ensure they're termintated
   $proc = Get-Process | Where-Object { $_.ProcessName -eq 'osqueryd' }
-  if ($proc -ne $null) {
+  if ($null -ne $proc) {
     Stop-Process -Force $proc -ErrorAction SilentlyContinue
   }
 

--- a/tools/deployment/make_windows_package.ps1
+++ b/tools/deployment/make_windows_package.ps1
@@ -213,7 +213,7 @@ $wix +=
               <ServiceInstall Id='osqueryd'
                 Name='osqueryd'
                 Account='NT AUTHORITY\SYSTEM'
-                Arguments='--flagfile=C:\ProgramData\osquery\osquery.flags'
+                Arguments='--flagfile=C:\Program Files\osquery\osquery.flags'
                 Start='auto'
                 Type='ownProcess'
                 Vital='yes'

--- a/tools/deployment/osquery.example.conf
+++ b/tools/deployment/osquery.example.conf
@@ -69,8 +69,8 @@
     // "vuln-management": "/usr/share/osquery/packs/vuln-management.conf",
     // "hardware-monitoring": "/usr/share/osquery/packs/hardware-monitoring.conf",
     // "ossec-rootkit": "/usr/share/osquery/packs/ossec-rootkit.conf",
-    // "windows-hardening": "C:\\ProgramData\\osquery\\packs\\windows-hardening.conf",
-    // "windows-attacks": "C:\\ProgramData\\osquery\\packs\\windows-attacks.conf"
+    // "windows-hardening": "C:\\Program Files\\osquery\\packs\\windows-hardening.conf",
+    // "windows-attacks": "C:\\Program Files\\osquery\\packs\\windows-attacks.conf"
   },
 
   // Provides feature vectors for osquery to leverage in simple statistical 

--- a/tools/provision/chocolatey/osquery_utils.ps1
+++ b/tools/provision/chocolatey/osquery_utils.ps1
@@ -9,6 +9,27 @@
 # Force Powershell to use TLS 1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
 
+#The osquery installation happens in Program Files
+$progFiles =  [System.Environment]::GetEnvironmentVariable('ProgramFiles')
+$targetFolder = Join-Path $progFiles 'osquery'
+
+# Maintain the daemon and extension folders for "safe" permissions management
+$daemonFolder = Join-Path $targetFolder 'osqueryd'
+$extensionsFolder = Join-Path $targetFolder 'extensions'
+$logFolder = Join-Path $targetFolder 'log'
+
+# Maintain the binary paths for creating the system service and extraction
+$targetDaemonBin = Join-Path $targetFolder "osqueryd.exe"
+$destDaemonBin = Join-Path $daemonFolder "osqueryd.exe"
+
+# Meta data for the system service installation
+$serviceName = 'osqueryd'
+$serviceDescription = 'osquery daemon service'
+
+# Track the old installation paths for removal
+$progData = [System.Environment]::GetEnvironmentVariable('ProgramData')
+$legacyInstall = Join-Path $progData "osquery"
+
 # Helper function to add an explicit Deny-Write ACE for the Everyone group
 function Set-DenyWriteAcl {
   [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Medium")]

--- a/tools/wel/osquery.man
+++ b/tools/wel/osquery.man
@@ -2,7 +2,7 @@
 <instrumentationManifest xsi:schemaLocation="http://schemas.microsoft.com/win/2004/08/events eventman.xsd" xmlns="http://schemas.microsoft.com/win/2004/08/events" xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:trace="http://schemas.microsoft.com/win/2004/08/events/trace">
 	<instrumentation>
 		<events>
-			<provider name="Facebook" guid="{F7740E18-3259-434F-9759-976319968900}" symbol="OsqueryWindowsEventLogProvider" resourceFileName="%systemdrive%\ProgramData\osquery\osqueryd\osqueryd.exe" messageFileName="%systemdrive%\ProgramData\osquery\osqueryd\osqueryd.exe">
+			<provider name="Facebook" guid="{F7740E18-3259-434F-9759-976319968900}" symbol="OsqueryWindowsEventLogProvider" resourceFileName="%systemdrive%\Program Files\osquery\osqueryd\osqueryd.exe" messageFileName="%systemdrive%\Program Files\osquery\osqueryd\osqueryd.exe">
 				<events>
 					<event symbol="DebugMessage" value="1" version="0" channel="osquery" level="win:Warning" task="LogMessage" opcode="MessageOpcode" template="_template_message" keywords="DebugWindowsEventLogMessage " message="$(string.osquery.event.1.message)"></event>
 					<event symbol="InfoMessage" value="2" version="0" channel="osquery" level="win:Informational" task="LogMessage" opcode="MessageOpcode" template="_template_message" keywords="InfoWindowsEventLogMessage " message="$(string.osquery.event.2.message)"></event>


### PR DESCRIPTION
This addresses issue #47 

Chocolatey provisioning and deployment scripts now install osquery to the `C:\Program Files\osquery` directory, and the example osquery.conf references `C:\Program Files` instead of `C:\ProgramData`

The osquery code itself has been updated to place the database and pidfile in `C:\Program Files\osquery`

Documentation has also been updated to reflect the new deployment location

This branch leans heavily on the [commits made in the original osquery repository](https://github.com/facebook/osquery/commit/c10914f199a140d3c1819fce3e0847008a393cca)